### PR TITLE
Converting end of line characters to Unix

### DIFF
--- a/buddypressorg.dev/provision/vvv-init.sh
+++ b/buddypressorg.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="buddypressorg.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"

--- a/helper-functions.sh
+++ b/helper-functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 
 # Download the global WordPress.org header into the given directory.
 #

--- a/jobs.wordpressnet.dev/provision/vvv-init.sh
+++ b/jobs.wordpressnet.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="jobs.wordpressnet.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"

--- a/translate.wordpressorg.dev/provision/vvv-init.sh
+++ b/translate.wordpressorg.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="translate.wordpressorg.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"

--- a/wordcamp.dev/provision/vvv-init.sh
+++ b/wordcamp.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="wordcamp.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="wordpressorg.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"

--- a/wordpresstv.dev/provision/vvv-init.sh
+++ b/wordpresstv.dev/provision/vvv-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 SITE_DOMAIN="wordpresstv.dev"
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"


### PR DESCRIPTION
End of line characters were in Windows format. I have converted them
back to Unix format, and tested them with `vagrant up --provision`. This
resolved some syntax errors. I had to add a whitespace for Git to accept
the commit.