### PR TITLE
Switch to RVM to install Sass

### DIFF
--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -37,7 +37,6 @@ if [ ! -d $SITE_DIR ]; then
 
 	# developer.wordpressorg.dev
 	composer create-project rmccue/wp-parser:dev-master $SITE_DIR/wp-content/plugins/wp-parser --no-dev --keep-vcs
-	sudo gem install sass
 
 	# global.wordpressorg.dev
 	svn propset svn:externals 'rosetta https://meta.svn.wordpress.org/sites/trunk/global.wordpress.org/public_html/wp-content/themes/rosetta/'             $SITE_DIR/wp-content/themes
@@ -77,7 +76,13 @@ else
 
 	# developer.wordpressorg.dev
 	# composer update rmccue/wp-parser # todo no composer.json file
-	sudo gem update sass
+	if command -v scss 2>/dev/null; then
+		#sass is good, just update it
+		/usr/bin/env rvm default do gem update sass
+	else
+		#sass didn't install earlier, so try again
+		/usr/bin/env rvm default do gem install sass --no-ri --no-rdoc
+	fi
 
 fi
 
@@ -86,5 +91,4 @@ wme_pull_wporg_global_header $SITE_DIR wp_head
 wme_pull_wporg_global_footer $SITE_DIR wp_footer
 
 # developer.wordpressorg.dev
-scss --no-cache --update --style=expanded    $SITE_DIR/wp-content/themes/pub/wporg-developer/scss:$SITE_DIR/wp-content/themes/pub/wporg-developer/stylesheets
-scss --no-cache --watch  --style=expanded -q $SITE_DIR/wp-content/themes/pub/wporg-developer/scss:$SITE_DIR/wp-content/themes/pub/wporg-developer/stylesheets &
+scss --no-cache --update --style=expanded -q $SITE_DIR/wp-content/themes/pub/wporg-developer/scss:$SITE_DIR/wp-content/themes/pub/wporg-developer/stylesheets


### PR DESCRIPTION
Using 'sudo' to install the sass gem makes it not available for use
to the rest of the script, since it's running outside sudo during
provision. Switching to using the already-installed RVM lets the
script use the 'scss' command during provision.

See #43.