### PR TITLE
Fixed: define GLOTPRESS_LOCALES_PATH constant in wp-config.php

### DIFF
--- a/wordpressorg.dev/provision/wp-config.php
+++ b/wordpressorg.dev/provision/wp-config.php
@@ -5,8 +5,8 @@ if ( ! isset( $_SERVER['HTTP_HOST'] ) ) {
 }
 
 $table_prefix  = 'wporg_';
-
 define( 'WPORGPATH',             dirname( __FILE__ ) . '/' );
+define( 'GLOTPRESS_LOCALES_PATH', __DIR__ . '/../../translate.wordpressorg.dev/public_html/glotpress/locales/locales.php' );
 define( 'API_WPORGPATH',         __DIR__ . '/../../api.wordpress.org/public_html/includes/' );
 define( 'WPORG_SANDBOXED',       true );
 


### PR DESCRIPTION
Once provision is done for the first time, a fatal error appears on http://wp-meta.dev :

`Fatal error: require_once(): Failed opening required 'GLOTPRESS_LOCALES_PATH' (include_path='.:/usr/share/php:/usr/share/pear') in /srv/www/wordpress-meta-environment/wordpressorg.dev/public_html/wp-content/mu-plugins/global_wordpressorg_dev/roles/rosetta-roles.php on line 11
`
Because GLOTPRESS_LOCALES_PATH is not defined anywhere. The following Pull Request should fix that issue.

Cheers