### PR TITLE
Add new plugin directory

### DIFF
--- a/wordpressorg.dev/provision/wp-config.php
+++ b/wordpressorg.dev/provision/wp-config.php
@@ -10,6 +10,8 @@ define( 'WPORGPATH',              dirname( __FILE__ ) . '/' );
 define( 'API_WPORGPATH',          __DIR__ . '/../../api.wordpress.org/public_html/includes/' );
 define( 'GLOTPRESS_LOCALES_PATH', __DIR__ . '/../../translate.wordpressorg.dev/public_html/glotpress/locales/locales.php' );
 define( 'WPORG_SANDBOXED',        true );
+define( 'PLUGINS_TABLE_PREFIX',   $table_prefix );
+define( 'WP_CORE_STABLE_BRANCH',  '4.5' );
 
 define( 'DB_NAME',                'wordpressorg_dev' );
 define( 'DB_USER',                'wp' );


### PR DESCRIPTION
Sets up a new site and populates it with data necessary to test and contribute to the new plugin directory.

I’m not sure why the SQL diff is so big, it probably shouldn’t need to delete 5K lines. I used the command outlined in the wiki to review DB changes:
`mysqldump --opt --compact --skip-extended-insert -u root -proot wordpressorg_dev > wordpressorg_dev.sql`

Please let me know if there is anything I can do to make this PR easier to review.