### PR TITLE
Remove Ruby SASS from wordpressorg.dev

### DIFF
--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -39,7 +39,6 @@ if [ ! -L $SITE_DIR ]; then
 
 	# developer.wordpressorg.dev
 	composer create-project rmccue/wp-parser:dev-master $SITE_DIR/wp-content/plugins/wp-parser --no-dev --keep-vcs
-	sudo gem install sass
 
 	# global.wordpressorg.dev
 	cd $SITE_DIR/wp-content/themes
@@ -98,14 +97,9 @@ else
 
 	# developer.wordpressorg.dev
 	# composer update rmccue/wp-parser # todo no composer.json file
-	sudo gem update sass
 
 fi
 
 # Pull global header/footer
 wme_pull_wporg_global_header $SITE_DIR wp_head
 wme_pull_wporg_global_footer $SITE_DIR wp_footer
-
-# developer.wordpressorg.dev
-scss --no-cache --update --style=expanded    $SITE_DIR/wp-content/themes/pub/wporg-developer/scss:$SITE_DIR/wp-content/themes/pub/wporg-developer/stylesheets
-scss --no-cache --watch  --style=expanded -q $SITE_DIR/wp-content/themes/pub/wporg-developer/scss:$SITE_DIR/wp-content/themes/pub/wporg-developer/stylesheets &


### PR DESCRIPTION
Ruby SASS for `developer.wordpress.org` was removed in [r3720](https://meta.trac.wordpress.org/changeset/3720/)