### PR TITLE
Updated URL of links to available sites.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ If you run into any problems with the instructions below, check out [the Trouble
 
 You're all set!
 
-* Visit [http://wp-meta.dev](http://wp-meta.dev) for links to all the available sites.
+* Visit [http://vvv.dev](http://vvv.dev) for links to all the available sites.
 * Log in to any of them with username `admin` and password `password`
 
 


### PR DESCRIPTION
When I tried following these directions, the given link didn't work, but http://vvv.dev seemed to provide links to all the sites.