### PR TITLE
VVV has been updated to use `vvv-config.yml` to add sites

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,15 @@ If you run into any problems with the instructions below, check out [the Trouble
 	
 	Make sure you have the latest version of VVV.
 
-1. In the `vagrant-local` folder edit `vvv-config.yml` and uncomment the line `wordpress-meta-environment: https://github.com/WordPress/meta-environment.git`
+1. In the `vagrant-local` folder edit `vvv-config.yml` and uncomment the following line:
+       
+       ```yml
+       #wordpress-meta-environment: https://github.com/WordPress/meta-environment.git
+       ```
+       to read
+       ```yml
+       wordpress-meta-environment: https://github.com/WordPress/meta-environment.git
+       ```
 
 1. Restart and re-provision VVV
 	1. `vagrant halt && vagrant up --provision`

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,17 +8,12 @@ If you run into any problems with the instructions below, check out [the Trouble
 
 	We recommend that you follow the step to install the `vagrant-hostsupdater` plugin, because if you don't then
 	you will need to manually add the hostnames for each WME site to your local hosts file.
+	
+	Make sure you have the latest version of VVV.
 
-1. Clone this repository as a subdirectory of VVV's `www` folder, and name the folder `wordpress-meta-environment`
-	1. `cd vagrant-local/www` (where `vagrant-local` is the name of your VVV folder)
-	1. `git clone https://github.com/WordPress/meta-environment.git wordpress-meta-environment`
-
-	**It's important that you clone the repository to a folder named `wordpress-meta-environment`.** If you choose
-	a different name, then WME will break during the provision stage, unless you also manually edit the Nginx
-	configuration files for each site to reflect the name you chose.
+1. In the `vagrant-local` folder edit `vvv-config.yml` and uncomment the line `wordpress-meta-environment: https://github.com/WordPress/meta-environment.git`
 
 1. Restart and re-provision VVV
-	1. `cd ..` (to get back to the main `vagrant-local` directory)
 	1. `vagrant halt && vagrant up --provision`
 	1. This will take roughly 10-30 minutes
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,7 @@ ugh wish vagrant or vvv just stored log by default. maybe there's something you 
 
 * **My IDE (or other tool) doesn't recognize `public_html` as a Git checkout:** Because `public_html` is a symlink, you may need to open `vagrant.local/www/wordpress-meta-environment/meta-repository/{site}/public_html` as the project root, instead of `vagrant.local/www/wordpress-meta-environment/{site}/public_html`. Another option is to use Git from the command line. 
 
+* **Databases not created:** If you ran `vagrant destroy` after provisioning and then re-provisioned the symlinks created the first time around won't be removed. These are used to determine whether to import the database and install plugins. Removing the symlinked `public_html` folders should fix it.
 
 ## Problems with specific sites
 


### PR DESCRIPTION
As the latest version VVV uses a `vvv-config.yml` file to list sites it should fetch and provision. The meta environment is already listed but is commented out by default.

This PR brings the docs up to date with VVV for anyone new like me trying to get setup!