### PR TITLE
WordCamp: Define WORDCAMP_ENVIRONMENT constant

### DIFF
--- a/wordcamp.dev/provision/wp-config.php
+++ b/wordcamp.dev/provision/wp-config.php
@@ -34,6 +34,7 @@ define( 'PATH_CURRENT_SITE',     '/' );
 define( 'SITE_ID_CURRENT_SITE',  1 );
 define( 'BLOG_ID_CURRENT_SITE',  2 );	// central.wordcamp.dev
 define( 'CLI_HOSTNAME_OVERRIDE', 'wordcamp.dev' );
+define( 'WORDCAMP_ENVIRONMENT',  'development' );
 
 define( 'WPLANG',               '' );
 define( 'WP_CONTENT_DIR',        __DIR__ . '/wp-content' );


### PR DESCRIPTION
On http://central.wordcamp.dev/ I get the following PHP Notice

> Notice: Use of undefined constant WORDCAMP_ENVIRONMENT - assumed 'WORDCAMP_ENVIRONMENT' in /srv/www/wordpress-meta-environment/meta-repository/wordcamp.org/public_html/wp-content/plugins/wordcamp-qbo/wordcamp-qbo.php on line 44

By defining the constant this notice goes away.