### PR TITLE
WordPress.org: Introduce support for Cavalcade

### DIFF
--- a/wordpressorg.dev/provision/cavalcade-wordpressorg.conf
+++ b/wordpressorg.dev/provision/cavalcade-wordpressorg.conf
@@ -1,0 +1,12 @@
+description "Cavalcade Runner for WordPress.org"
+
+start on vagrant-mounted MOUNTPOINT=/srv/www
+stop on runlevel [!2345]
+
+respawn
+respawn limit unlimited
+kill timeout 600
+
+chdir /srv/www/wordpress-meta-environment/wordpressorg.dev/public_html
+setuid vagrant
+exec /etc/cavalcade/bin/cavalcade

--- a/wordpressorg.dev/provision/cavalcade.php
+++ b/wordpressorg.dev/provision/cavalcade.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/cavalcade/plugin.php';

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -98,16 +98,19 @@ if [ ! -L $SITE_DIR ]; then
 	IGNORED_FILES=(
 		/wordpress
 		/wp-content/languages
-		/wp-content/mu-plugins/cavalcade
+		/wp-content/mu-plugins/cavalcade*
 		/wp-content/mu-plugins/global_wordpressorg_dev
 		/wp-content/mu-plugins/sandbox-functionality.php
 		/wp-content/plugins/phpdoc-parser
+		/wp-content/plugins/glotpress
 		/wp-content/themes/p2
 		/wp-content/themes/rosetta
+		/wp-content/themes/twenty*
 		/wp-content/sunrise.php
 		/footer.php
 		/header.php
 		/wp-config.php
+		/wp-cli.yml
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" )
 	wme_create_gitignore $SITE_DIR

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -79,10 +79,25 @@ if [ ! -L $SITE_DIR ]; then
 		wme_download_pomo "${gplocale}" "meta/o2" "$SITE_DIR/wp-content/languages/themes/o2-${locale}"
 	done
 
+	# Cavalcade
+	printf "Installing Cavalcade..."
+	git clone https://github.com/humanmade/Cavalcade.git $SITE_DIR/wp-content/mu-plugins/cavalcade
+	cp $PROVISION_DIR/cavalcade.php $SITE_DIR/wp-content/mu-plugins/
+
+	if [[ ! -d "/etc/cavalcade" ]]; then
+		git clone https://github.com/humanmade/Cavalcade-Runner.git /etc/cavalcade
+	else
+		git -C /etc/cavalcade pull
+	fi
+
+	cp "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
+	service cavalcade-wordpressorg restart
+
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
 		/wordpress
 		/wp-content/languages
+		/wp-content/mu-plugins/cavalcade
 		/wp-content/mu-plugins/global_wordpressorg_dev
 		/wp-content/mu-plugins/sandbox-functionality.php
 		/wp-content/plugins/phpdoc-parser
@@ -125,7 +140,16 @@ else
 
 	# developer.wordpressorg.dev
 	git -C $SITE_DIR/wp-content/plugins/phpdoc-parser pull
+
+	# translate.wordpressorg.dev
 	git -C $SITE_DIR/wp-content/plugins/glotpress pull
+
+	# Cavalcade
+	git -C $SITE_DIR/wp-content/mu-plugins/cavalcade pull
+	git -C /etc/cavalcade pull
+	cp "$PROVISION_DIR/cavalcade.php" "$SITE_DIR/wp-content/mu-plugins/"
+	cp "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
+	service cavalcade-wordpressorg restart
 fi
 
 # Pull global header/footer

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -32,6 +32,7 @@ if [ ! -L $SITE_DIR ]; then
 	wme_noroot wp core download --version=nightly --path=$SITE_DIR/wordpress
 	mkdir -p $SITE_DIR/wp-content/mu-plugins
 	cp $PROVISION_DIR/wp-config.php             $SITE_DIR
+	cp $PROVISION_DIR/wp-cli.yml                $SITE_DIR
 	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
 	cp $PROVISION_DIR/sunrise.php               $SITE_DIR/wp-content
 

--- a/wordpressorg.dev/provision/wp-cli.yml
+++ b/wordpressorg.dev/provision/wp-cli.yml
@@ -1,0 +1,1 @@
+path: wordpress

--- a/wordpressorg.dev/provision/wp-config.php
+++ b/wordpressorg.dev/provision/wp-config.php
@@ -55,6 +55,9 @@ define( 'WPORG_GLOBAL_NETWORK_ID',       6 );
 define( 'WPORG_THEME_DIRECTORY_BLOGID',  35 );
 define( 'WPORG_PLUGIN_DIRECTORY_BLOGID', 367 );
 
+// Disable WordPress Cron, we've got Cavalcade processing jobs instead.
+define( 'DISABLE_WP_CRON', true );
+
 define( 'GLOTPRESS_LOCALES_PATH', dirname( dirname( dirname( __DIR__ ) ) ) . '/meta-repository/wordpress.org/public_html/wp-content/plugins/glotpress/locales/locales.php' );
 define( 'GLOTPRESS_TABLE_PREFIX', 'translate_' );
 
@@ -85,7 +88,7 @@ if ( $_SERVER['HTTP_HOST'] === 'make.wordpressorg.dev' ) {
 	define( 'SITE_ID_CURRENT_SITE', 1 );
 	define( 'BLOG_ID_CURRENT_SITE', 1 );
 	define( 'SUBDOMAIN_INSTALL',    false );
-	
+
 } elseif ( $_SERVER['HTTP_HOST'] === 'translate.wordpressorg.dev' ) {
 	define( 'DB_CHARSET', 'latin1' );
 	define( 'GP_TMPL_PATH',  WPORGPATH . 'wp-content/plugins/wporg-gp-customizations/templates/' );


### PR DESCRIPTION
* Loads https://github.com/humanmade/Cavalcade-Runner into `/etc/cavalcade`
* Adds upstart service `cavalcade-wordpressorg`
* Adds `wp-cli.yml` for the WP-CLI command `wp cavalcade`
* Loads https://github.com/humanmade/Cavalcade into `mu-plugins/cavalcade`
* Disables WordPress' cron by adding `define( 'DISABLE_WP_CRON', true );`
* Updates content for `.gitignore`, related #98