### PR TITLE
Use .git/info/exclude instead of multiple .gitignore

### DIFF
--- a/buddypressorg.test/provision/vvv-init.sh
+++ b/buddypressorg.test/provision/vvv-init.sh
@@ -46,12 +46,12 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
-		/wordpress
-		/wp-content/mu-plugins/sandbox-functionality.php
-		/wp-config.php
+		**/wordpress
+		**/wp-content/mu-plugins/sandbox-functionality.php
+		**/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_git_exclude "$BASE_DIR/meta-repository"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"

--- a/buddypressorg.test/provision/vvv-init.sh
+++ b/buddypressorg.test/provision/vvv-init.sh
@@ -46,6 +46,7 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
+		**/logs
 		**/wordpress
 		**/wp-content/mu-plugins/sandbox-functionality.php
 		**/wp-config.php

--- a/helper-functions.sh
+++ b/helper-functions.sh
@@ -47,19 +47,15 @@ function wme_symlink_logs_dir {
 	mkdir -p $LOGS_DIR_PATH
 }
 
-# Add entries to a .gitignore file
-#
-# todo use .git/info/exclude instead, that's more appropriate for this situation
+# Add entries to the .git/info/exclude file
 #
 # $1 - the site's web root
-function wme_create_gitignore {
-	# Ignore the .gitignore file itself
-	echo "/.gitignore" >> $1/.gitignore
-
+function wme_create_git_exclude {
 	for i in "${IGNORED_FILES[@]}"
 	do :
-		echo "$i" >> $1/.gitignore
+		echo "$i" >> $1/.git/info/exclude
 	done
+	awk '!a[$0]++' $1/.git/info/exclude > exclude && mv exclude $1/.git/info/exclude
 }
 
 # Download the global WordPress.org header into the given directory.

--- a/jobs.wordpressnet.test/provision/vvv-init.sh
+++ b/jobs.wordpressnet.test/provision/vvv-init.sh
@@ -37,12 +37,12 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
-		/wordpress
-		/wp-content/mu-plugins/sandbox-functionality.php
-		/wp-content/plugins/si-contact-form
-		/wp-config.php
+		**/wordpress
+		**/wp-content/mu-plugins/sandbox-functionality.php
+		**/wp-content/plugins/si-contact-form
+		**/wp-config.php
 	)
-	wme_create_gitignore $SITE_DIR
+	wme_create_git_exclude "$BASE_DIR/meta-repository"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"

--- a/jobs.wordpressnet.test/provision/vvv-init.sh
+++ b/jobs.wordpressnet.test/provision/vvv-init.sh
@@ -37,6 +37,7 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
+		**/logs
 		**/wordpress
 		**/wp-content/mu-plugins/sandbox-functionality.php
 		**/wp-content/plugins/si-contact-form

--- a/wordcamp.test/provision/vvv-init.sh
+++ b/wordcamp.test/provision/vvv-init.sh
@@ -61,6 +61,7 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
+		**/logs
 		**/wordpress
 		**/wp-content/mu-plugins/sandbox-functionality.php
 		**/wp-content/plugins/camptix

--- a/wordcamp.test/provision/vvv-init.sh
+++ b/wordcamp.test/provision/vvv-init.sh
@@ -61,13 +61,13 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
-		/wordpress
-		/wp-content/mu-plugins/sandbox-functionality.php
-		/wp-content/plugins/camptix
-		/wp-config.php
+		**/wordpress
+		**/wp-content/mu-plugins/sandbox-functionality.php
+		**/wp-content/plugins/camptix
+		**/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" "${WPCLI_THEMES[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_git_exclude "$BASE_DIR/meta-repository"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"

--- a/wordpressorg.test/provision/vvv-init.sh
+++ b/wordpressorg.test/provision/vvv-init.sh
@@ -99,6 +99,7 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
+		**/logs
 		**/wordpress
 		**/wp-content/languages
 		**/wp-content/mu-plugins/cavalcade*

--- a/wordpressorg.test/provision/vvv-init.sh
+++ b/wordpressorg.test/provision/vvv-init.sh
@@ -15,6 +15,7 @@ PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
 SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
 SVN_PLUGINS=( akismet bbpress debug-bar debug-bar-cron email-post-changes speakerdeck-embed supportflow syntaxhighlighter two-factor wordpress-importer )
 WPCLI_PLUGINS=( jetpack tinymce-code-element wp-multibyte-patch )
+THEMES=( twenty* rosetta p2  )
 WP_LOCALES=( ja es_ES )
 
 wme_svn_git_migration $SITE_DIR
@@ -98,24 +99,19 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
-		/wordpress
-		/wp-content/languages
-		/wp-content/mu-plugins/cavalcade*
-		/wp-content/mu-plugins/global_wordpressorg_dev
-		/wp-content/mu-plugins/sandbox-functionality.php
-		/wp-content/plugins/phpdoc-parser
-		/wp-content/plugins/glotpress
-		/wp-content/themes/p2
-		/wp-content/themes/rosetta
-		/wp-content/themes/twenty*
-		/wp-content/sunrise.php
-		/footer.php
-		/header.php
-		/wp-config.php
-		/wp-cli.yml
+		**/wordpress
+		**/wp-content/languages
+		**/wp-content/mu-plugins/cavalcade*
+		**/wp-content/mu-plugins/global_wordpressorg_dev
+		**/wp-content/mu-plugins/sandbox-functionality.php
+		**/wp-content/sunrise.php
+		wordpress.org/footer.php
+		wordpress.org/header.php
+		**/wp-config.php
+		**/wp-cli.yml
 	)
-	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${GIT_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" "${THEMES[@]}" )
+	wme_create_git_exclude "$BASE_DIR/meta-repository"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"

--- a/wordpresstv.test/provision/vvv-init.sh
+++ b/wordpresstv.test/provision/vvv-init.sh
@@ -38,6 +38,7 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
+		**/logs
 		**/wordpress
 		**/wp-content/mu-plugins/sandbox-functionality.php
 		**/wp-config.php

--- a/wordpresstv.test/provision/vvv-init.sh
+++ b/wordpresstv.test/provision/vvv-init.sh
@@ -38,12 +38,12 @@ if [ ! -L $SITE_DIR ]; then
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
-		/wordpress
-		/wp-content/mu-plugins/sandbox-functionality.php
-		/wp-config.php
+		**/wordpress
+		**/wp-content/mu-plugins/sandbox-functionality.php
+		**/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_git_exclude "$BASE_DIR/meta-repository"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"


### PR DESCRIPTION
fixes #107 

Exclude `logs` directories introduced in https://github.com/WordPress/meta-environment/commit/3f64897013c6d2b15fccf5f39988f49fb972c0c9