### PR TITLE
Wordcamp: Remove json-rest-api plugin which is merged in core.

### DIFF
--- a/wordcamp.test/provision/vvv-init.sh
+++ b/wordcamp.test/provision/vvv-init.sh
@@ -15,7 +15,7 @@ BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
 SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
 SVN_PLUGINS=( camptix-network-tools email-post-changes tagregator supportflow camptix-pagseguro camptix-payfast-gateway camptix-trustpay camptix-trustcard camptix-mercadopago camptix-kdcpay-gateway campt-indian-payment-gateway )
-WPCLI_PLUGINS=( akismet buddypress bbpress jetpack json-rest-api wp-multibyte-patch wordpress-importer polldaddy liveblog wp-super-cache custom-content-width )
+WPCLI_PLUGINS=( akismet buddypress bbpress jetpack wp-multibyte-patch wordpress-importer polldaddy liveblog wp-super-cache custom-content-width )
 WPCLI_THEMES=( twentyten twentyeleven twentytwelve twentythirteen )
 
 wme_svn_git_migration $SITE_DIR


### PR DESCRIPTION
Was added in commit #ad848f3 to fix issue #38 

_May need testing as `wordcamp.test/provision/wordcamp_dev.sql` is altered manually._