### PR TITLE
Speed up Initial Provision

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This loads the various provisioners for each site in the meta environment,
+# so that VVV doesn't have to do a folder search to find them
+
+echo "Beginning WP Meta Environment provisioning"
+
+source ../buddypressorg.test/provision/vvv-init.sh
+source ../jobs.wordpressnet.test/provision/vvv-init.sh
+source ../wordcamp.test/provision/vvv-init.sh
+source ../wordpressorg.test/provision/vvv-init.sh
+source ../wordpresstv.test/provision/vvv-init.sh
+
+echo "Completed WP Meta Environment provisioning"


### PR DESCRIPTION
By putting in a `provision/vvv-init.sh` and loading the other provisioners, VVV preferentially loads it, avoiding a folder search that takes time.

This also means that in the future the check to see if a site should be provisioned can be moved here, simplifying things, or even parallelising things. Note that i haven't tested this yet, it might be necessary to load the helper script in this file and remove it from the other provisioners