### PR TITLE
Add a forward slash to match path & load pub files.

### DIFF
--- a/wordpressorg.test/provision/sandbox-functionality.php
+++ b/wordpressorg.test/provision/sandbox-functionality.php
@@ -9,7 +9,7 @@ define( 'WP_CORE_STABLE_BRANCH', '4.5' );
 register_theme_directory( ABSPATH . 'wp-content/themes' );
 
 // Load global must-use plugins.
-foreach ( glob( __DIR__ . "pub/*.php" ) as $filename ) {
+foreach ( glob( __DIR__ . "/pub/*.php" ) as $filename ) {
 	require_once( $filename );
 }
 


### PR DESCRIPTION
`__DIR__` is missing a trailing slash.