### PR TITLE
Remove RECOMMENDED_PHP from config.

### DIFF
--- a/wordpressorg.test/provision/wp-config.php
+++ b/wordpressorg.test/provision/wp-config.php
@@ -57,7 +57,6 @@ define( 'WPORG_PLUGIN_DIRECTORY_BLOGID', 367 );
 define( 'WPORG_TRANSLATE_BLOGID',        351 );
 define( 'WPORG_SUPPORT_FORUMS_BLOGID',   368 );
 define( 'WP_CORE_LATEST_RELEASE',        '5.4' );
-define( 'RECOMMENDED_PHP',               7.1 );
 
 
 // Disable WordPress Cron, we've got Cavalcade processing jobs instead.


### PR DESCRIPTION
This was added to solve the problem of it being missing.

The problem was that `/pub` plugins were not being loading.

https://github.com/WordPress/meta-environment/pull/142 Should be merged first.
 