### PR TITLE
Fix Issue 151 - Anti parameter expansion fixes

### DIFF
--- a/buddypressorg.test/provision/vvv-init.sh
+++ b/buddypressorg.test/provision/vvv-init.sh
@@ -2,47 +2,47 @@
 SITE_DOMAIN="buddypressorg.test"
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-source $BASE_DIR/helper-functions.sh
+source "${BASE_DIR}/helper-functions.sh"
 
-wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
+wme_create_logs "${BASE_DIR}/${SITE_DOMAIN}/logs"
 
 if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 	echo "Provisioning of ${SITE_DOMAIN} skipped"
 	return
 fi
 
-PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
-SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
+PROVISION_DIR="${BASE_DIR}/${SITE_DOMAIN}/provision"
+SITE_DIR="${BASE_DIR}/${SITE_DOMAIN}/public_html"
 SVN_PLUGINS=( buddypress bbpress )
 WPCLI_PLUGINS=( akismet bbpress-no-admin debug-bar email-post-changes syntaxhighlighter )
 
-wme_svn_git_migration $SITE_DIR
+wme_svn_git_migration "${SITE_DIR}"
 
-if [ ! -L $SITE_DIR ]; then
-	printf "\n#\n# Provisioning $SITE_DOMAIN\n#\n"
+if [ ! -L "${SITE_DIR}" ]; then
+	printf "\n#\n# Provisioning ${SITE_DOMAIN}\n#\n"
 
-	if [[ ! $MIGRATED_TO_GIT ]]; then
-		wme_import_database "buddypressorg_dev" $PROVISION_DIR
+	if [[ ! "${MIGRATED_TO_GIT}" ]]; then
+		wme_import_database "buddypressorg_dev" "$PROVISION_DIR"
 	fi
 
-	wme_clone_meta_repository $BASE_DIR
-	wme_symlink_public_dir $BASE_DIR $SITE_DOMAIN "buddypress.org"
-	wme_symlink_logs_dir $BASE_DIR $SITE_DOMAIN "buddypress.org"
+	wme_clone_meta_repository "${BASE_DIR}"
+	wme_symlink_public_dir "${BASE_DIR}" "${SITE_DOMAIN}" "buddypress.org"
+	wme_symlink_logs_dir "${BASE_DIR}" "${SITE_DOMAIN}" "buddypress.org"
 
 	# Set up WordPress
-	wme_noroot wp core download --path=$SITE_DIR/wordpress
-	cp $PROVISION_DIR/wp-config.php $SITE_DIR
+	wme_noroot wp core download --path="${SITE_DIR}/wordpress"
+	cp "${PROVISION_DIR}/wp-config.php" "${SITE_DIR}"
 
 	# Set up plugins and themes
 	for i in "${SVN_PLUGINS[@]}"
 	do :
-		svn co https://plugins.svn.wordpress.org/$i/trunk $SITE_DIR/wp-content/plugins/$i
+		svn co "https://plugins.svn.wordpress.org/${i}/trunk" "${SITE_DIR}/wp-content/plugins/${i}"
 	done
 
-	wp plugin install ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress --allow-root
+	wp plugin install ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress" --allow-root
 
-	mkdir $SITE_DIR/wp-content/mu-plugins
-	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
+	mkdir "${SITE_DIR}/wp-content/mu-plugins"
+	cp "${PROVISION_DIR}/sandbox-functionality.php" "${SITE_DIR}/wp-content/mu-plugins/"
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
@@ -51,18 +51,18 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_gitignore "${SITE_DIR}"
 
 else
-	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
+	printf "\n#\n# Updating ${SITE_DOMAIN}\n#\n"
 
-	git -C $SITE_DIR pull origin master
-	wp core   update --path=$SITE_DIR/wordpress --allow-root
-	wp plugin update ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress --allow-root
+	git -C "${SITE_DIR}" pull origin master
+	wp core   update --path="${SITE_DIR}/wordpress" --allow-root
+	wp plugin update ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress" --allow-root
 
 	for i in "${SVN_PLUGINS[@]}"
 	do :
-		svn up $SITE_DIR/wp-content/plugins/$i
+		svn up "${SITE_DIR}/wp-content/plugins/${i}"
 	done
 
 fi

--- a/helper-functions.sh
+++ b/helper-functions.sh
@@ -9,12 +9,12 @@
 function wme_clone_meta_repository {
 	local REPOSITORY_DIR="$1/meta-repository"
 
-	if [ -d $REPOSITORY_DIR ]; then
+	if [ -d "${REPOSITORY_DIR}" ]; then
 		return 0
 	fi
 
-	git clone git://meta.git.wordpress.org/ $REPOSITORY_DIR
-	git -C $REPOSITORY_DIR config diff.noprefix true
+	git clone git://meta.git.wordpress.org/ "${REPOSITORY_DIR}"
+	git -C "${REPOSITORY_DIR}" config diff.noprefix true
 }
 
 # Symlink each site's public_html folder to the corresponding Meta repository
@@ -30,8 +30,8 @@ function wme_symlink_public_dir {
 	PUBLIC_DIR_PATH="$1/meta-repository/$3/public_html/"
 
 	cd "$1/$2"
-	ln -rs $PUBLIC_DIR_PATH public_html
-	mkdir -p $PUBLIC_DIR_PATH
+	ln -rs "${PUBLIC_DIR_PATH}" public_html
+	mkdir -p "${PUBLIC_DIR_PATH}"
 }
 
 # Symlink each site's log folder to the default log folder.
@@ -43,8 +43,8 @@ function wme_symlink_logs_dir {
 	LOGS_DIR_PATH="$1/$2/logs"
 
 	cd "$1/meta-repository/$3"
-	ln -rs $LOGS_DIR_PATH logs
-	mkdir -p $LOGS_DIR_PATH
+	ln -rs "${LOGS_DIR_PATH}" logs
+	mkdir -p "${LOGS_DIR_PATH}"
 }
 
 # Add entries to a .gitignore file
@@ -58,7 +58,7 @@ function wme_create_gitignore {
 
 	for i in "${IGNORED_FILES[@]}"
 	do :
-		echo "$i" >> $1/.gitignore
+		echo "$i" >> "$1/.gitignore"
 	done
 }
 
@@ -68,17 +68,17 @@ function wme_create_gitignore {
 #
 # $1 - the absolute path to the folder where the header should be placed
 function wme_pull_wporg_global_header {
-	curl -so $1/header.php https://wordpress.org/header.php
+	curl -so "$1/header.php" https://wordpress.org/header.php
 
-	sed -i "s/<\/head>/\n<?php\nif ( function_exists( 'gp_head' ) ) {\n\tgp_head();\n} else {\n\twp_head();\n}\n?>\n\n&/" $1/header.php
-	sed -i "s/<body id=\"wordpress-org\"/<body id=\"wordpress-org\" <?php if ( function_exists( 'body_class' ) ) { body_class(); } ?>/" $1/header.php
+	sed -i "s/<\/head>/\n<?php\nif ( function_exists( 'gp_head' ) ) {\n\tgp_head();\n} else {\n\twp_head();\n}\n?>\n\n&/" "$1/header.php"
+	sed -i "s/<body id=\"wordpress-org\"/<body id=\"wordpress-org\" <?php if ( function_exists( 'body_class' ) ) { body_class(); } ?>/" "$1/header.php"
 
 	# Replace the links to point locally
 	# Match: //wordpress.org -> //wordpressorg.test
-	sed -i -e 's/\/\/wordpress.org/\/\/wordpressorg.test/g' $1/header.php
+	sed -i -e 's/\/\/wordpress.org/\/\/wordpressorg.test/g' "$1/header.php"
 
 	# Match: make.wordpress.org -> make.wordpressorg.test
-	sed -i -e 's/make.wordpress.org/make.wordpressorg.test/g' $1/header.php
+	sed -i -e 's/make.wordpress.org/make.wordpressorg.test/g' "$1/header.php"
 }
 
 # Download the global WordPress.org footer into the given directory.
@@ -87,15 +87,15 @@ function wme_pull_wporg_global_header {
 #
 # $1 - the absolute path to the folder where the footer should be placed
 function wme_pull_wporg_global_footer {
-	curl -so $1/footer.php https://wordpress.org/footer.php
+	curl -so "$1/footer.php" https://wordpress.org/footer.php
 
 	sed -i "s/<\/body>/\n<?php\nif ( function_exists( 'gp_footer' ) ) {\n\tgp_footer();\n} else {\n\twp_footer();\n}\n?>\n\n&/" $1/footer.php
 
 	# Replace the links to point locally
 	# Match: //wordpress.org -> //wordpressorg.test
-	sed -i -e 's/\/\/wordpress.org/\/\/wordpressorg.test/g' $1/footer.php
+	sed -i -e 's/\/\/wordpress.org/\/\/wordpressorg.test/g' "$1/footer.php"
 	# Match: .wordpress.org -> .wordpressorg.test
-	sed -i -e 's/.wordpress.org/.wordpressorg.test/g' $1/footer.php
+	sed -i -e 's/.wordpress.org/.wordpressorg.test/g' "$1/footer.php"
 }
 
 # Create log stubs
@@ -103,11 +103,11 @@ function wme_pull_wporg_global_footer {
 # $1 - the absolute path to the log folder
 function wme_create_logs {
 	echo "Creating log files in ${1}"
-	mkdir -p $1
+	mkdir -p "$1"
 
-	touch $1/nginx-access.log
-	touch $1/nginx-error.log
-	touch $1/php-error.log
+	touch "$1/nginx-access.log"
+	touch "$1/nginx-error.log"
+	touch "$1/php-error.log"
 }
 
 # Import a MySQL database
@@ -119,7 +119,7 @@ function wme_import_database {
 	mysql -u root --password=root -e "CREATE DATABASE IF NOT EXISTS $1;"
 	mysql -u root --password=root -e "GRANT ALL PRIVILEGES ON $1.* TO wp@localhost IDENTIFIED BY 'wp';"
 	echo "Importing database ${2}/${1}.sql"
-	mysql -u root --password=root $1 < "${2}/${1}.sql"
+	mysql -u root --password=root "$1" < "${2}/${1}.sql"
 	echo "Finished database import operations for ${1}"
 }
 
@@ -138,7 +138,7 @@ function wme_svn_git_migration {
 	echo "If you're working on any unfinished patches, please copy them from the backup folder."
 	echo -e "For help contributing with Git, see https://make.wordpress.org/meta/handbook/documentation/contributing-with-git/\n"
 
-	mv $1 "$1-old-svn-backup"
+	mv "$1" "$1-old-svn-backup"
 	MIGRATED_TO_GIT=true
 }
 
@@ -156,7 +156,7 @@ function wme_noroot() {
 function wme_provision_site {
 	WME_SITE_ESCAPED=`echo ${1} | sed 's/\./\\\\./g'`
 	WME_PROVISION_SITE=`get_config_value "provision_site.${WME_SITE_ESCAPED}" 'true'`
-	echo ${WME_PROVISION_SITE,,}
+	echo "${WME_PROVISION_SITE,,}"
 }
 
 # Loads mo/mo files from translate.wordpress.org.
@@ -165,10 +165,10 @@ function wme_provision_site {
 # $2 - Slug of GlotPress project
 # $3 - File path without the PO/MO extension
 function wme_download_pomo {
-	local GPLOCALE=$1
-	local GPPROJECT=$2
-	local OUTPUT=$3
+	local GPLOCALE="$1"
+	local GPPROJECT="$2"
+	local OUTPUT="$3"
 
-	curl -sfg -o $OUTPUT.po "https://translate.wordpress.org/projects/$GPPROJECT/$GPLOCALE/default/export-translations?filters[status]=current&format=po" || echo "Error downloading ${GPPROJECT}-${GPLOCALE}.po"
-	curl -sfg -o $OUTPUT.mo "https://translate.wordpress.org/projects/$GPPROJECT/$GPLOCALE/default/export-translations?filters[status]=current&format=mo" || echo "Error downloading ${GPPROJECT}-${GPLOCALE}.mo"
+	curl -sfg -o "${OUTPUT}.po" "https://translate.wordpress.org/projects/${GPPROJECT}/${GPLOCALE}/default/export-translations?filters[status]=current&format=po" || echo "Error downloading ${GPPROJECT}-${GPLOCALE}.po"
+	curl -sfg -o "${OUTPUT}.mo" "https://translate.wordpress.org/projects/${GPPROJECT}/${GPLOCALE}/default/export-translations?filters[status]=current&format=mo" || echo "Error downloading ${GPPROJECT}-${GPLOCALE}.mo"
 }

--- a/jobs.wordpressnet.test/provision/vvv-init.sh
+++ b/jobs.wordpressnet.test/provision/vvv-init.sh
@@ -2,29 +2,29 @@
 SITE_DOMAIN="jobs.wordpressnet.test"
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-source $BASE_DIR/helper-functions.sh
+source "${BASE_DIR}/helper-functions.sh"
 
-wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
+wme_create_logs "${BASE_DIR}/${SITE_DOMAIN}/logs"
 
 if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 	echo "Provisioning of ${SITE_DOMAIN} skipped"
 	return
 fi
 
-PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
-SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
+PROVISION_DIR="${BASE_DIR}/${SITE_DOMAIN}/provision"
+SITE_DIR="${BASE_DIR}/${SITE_DOMAIN}/public_html"
 
 wme_svn_git_migration "${SITE_DIR}"
 
-if [ ! -L $SITE_DIR ]; then
-	printf "\n#\n# Provisioning $SITE_DOMAIN\n#\n"
+if [ ! -L "$SITE_DIR" ]; then
+	printf "\n#\n# Provisioning ${SITE_DOMAIN}\n#\n"
 
 	# Don't overwrite existing databases if we're just migrating from SVN to Git
-	if [[ ! $MIGRATED_TO_GIT ]]; then
+	if [[ ! "$MIGRATED_TO_GIT" ]]; then
 		wme_import_database "jobs_wordpressnet_dev" "${PROVISION_DIR}"
 	fi
 
-	wme_clone_meta_repository $BASE_DIR
+	wme_clone_meta_repository "${BASE_DIR}"
 	wme_symlink_public_dir "${BASE_DIR}" "${SITE_DOMAIN}" "jobs.wordpress.net"
 	wme_symlink_logs_dir "${BASE_DIR}" "${SITE_DOMAIN}" "jobs.wordpress.net"
 
@@ -41,10 +41,10 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-content/plugins/si-contact-form
 		/wp-config.php
 	)
-	wme_create_gitignore $SITE_DIR
+	wme_create_gitignore "$SITE_DIR"
 
 else
-	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
+	printf "\n#\n# Updating ${SITE_DOMAIN}\n#\n"
 
 	git -C "${SITE_DIR}" pull origin master
 	wme_noroot wp core   update --version=nightly --path="${SITE_DIR}/wordpress"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -9,10 +9,10 @@ BASE_DIR="$( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd 
 
 # Launch each provisioner in a subshell to avoid conflicting global variable names.
 # For example, `$BASE_DIR` would be overridden by each provisioner.
-( source $BASE_DIR/buddypressorg.test/provision/vvv-init.sh     )
-( source $BASE_DIR/jobs.wordpressnet.test/provision/vvv-init.sh )
-( source $BASE_DIR/wordcamp.test/provision/vvv-init.sh          )
-( source $BASE_DIR/wordpressorg.test/provision/vvv-init.sh      )
-( source $BASE_DIR/wordpresstv.test/provision/vvv-init.sh       )
+( source "${BASE_DIR}/buddypressorg.test/provision/vvv-init.sh"     )
+( source "${BASE_DIR}/jobs.wordpressnet.test/provision/vvv-init.sh" )
+( source "${BASE_DIR}/wordcamp.test/provision/vvv-init.sh"          )
+( source "${BASE_DIR}/wordpressorg.test/provision/vvv-init.sh"      )
+( source "${BASE_DIR}/wordpresstv.test/provision/vvv-init.sh"       )
 
 echo "Completed WordPress Meta Environment provisioning"

--- a/wordcamp.test/provision/vvv-init.sh
+++ b/wordcamp.test/provision/vvv-init.sh
@@ -2,9 +2,9 @@
 SITE_DOMAIN="wordcamp.test"
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-source $BASE_DIR/helper-functions.sh
+source "${BASE_DIR}/helper-functions.sh"
 
-wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
+wme_create_logs "${BASE_DIR}/${SITE_DOMAIN}/logs"
 
 if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 	echo "Provisioning of ${SITE_DOMAIN} skipped"
@@ -12,13 +12,13 @@ if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 fi
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
-SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
+PROVISION_DIR="${BASE_DIR}/${SITE_DOMAIN}/provision"
+SITE_DIR="${BASE_DIR}/${SITE_DOMAIN}/public_html"
 SVN_PLUGINS=( camptix-network-tools email-post-changes tagregator supportflow camptix-pagseguro camptix-payfast-gateway camptix-trustpay camptix-trustcard camptix-mercadopago camptix-kdcpay-gateway campt-indian-payment-gateway )
 WPCLI_PLUGINS=( akismet buddypress bbpress jetpack wp-multibyte-patch wordpress-importer polldaddy pwa liveblog wp-super-cache custom-content-width )
 WPCLI_THEMES=( twentyten twentyeleven twentytwelve twentythirteen )
 
-wme_svn_git_migration $SITE_DIR
+wme_svn_git_migration "${SITE_DIR}"
 
 # Install wkhtmltopdf for wordcamp-docs plugin
 if [ ! -f /usr/local/bin/wkhtmltopdf ]; then
@@ -29,28 +29,28 @@ if [ ! -f /usr/local/bin/wkhtmltopdf ]; then
 	ln -s /usr/bin/wkhtmltopdf.sh /usr/local/bin/wkhtmltopdf
 fi
 
-if [ ! -L $SITE_DIR ]; then
-	printf "\n#\n# Provisioning $SITE_DOMAIN\n#\n"
+if [ ! -L "${SITE_DIR}" ]; then
+	printf "\n#\n# Provisioning ${SITE_DOMAIN}\n#\n"
 
 	# Don't overwrite existing databases if we're just migrating from SVN to Git
-	if [[ ! $MIGRATED_TO_GIT ]]; then
-		wme_import_database "wordcamp_dev" $PROVISION_DIR
+	if [[ ! "${MIGRATED_TO_GIT}" ]]; then
+		wme_import_database "wordcamp_dev" "${PROVISION_DIR}"
 	fi
 
-	wme_clone_meta_repository $BASE_DIR
-	wme_symlink_public_dir $BASE_DIR $SITE_DOMAIN "wordcamp.org"
-	wme_symlink_logs_dir $BASE_DIR $SITE_DOMAIN "wordcamp.org"
+	wme_clone_meta_repository "${BASE_DIR}"
+	wme_symlink_public_dir "${BASE_DIR}" "${SITE_DOMAIN}" "wordcamp.org"
+	wme_symlink_logs_dir "${BASE_DIR}" "${SITE_DOMAIN}" "wordcamp.org"
 
 	# Setup WordPress
-	wme_noroot wp core download --path=$SITE_DIR/wordpress
-	cp $PROVISION_DIR/wp-config.php $SITE_DIR
+	wme_noroot wp core download --path="${SITE_DIR}/wordpress"
+	cp "$PROVISION_DIR/wp-config.php" "${SITE_DIR}"
 
 	# Setup mu-plugin for local development
-	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
+	cp "$PROVISION_DIR/sandbox-functionality.php" "${SITE_DIR}/wp-content/mu-plugins/"
 
 	# Install extra plugins and themes
-	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress
-	wme_noroot wp theme  install ${WPCLI_THEMES[@]}  --path=$SITE_DIR/wordpress
+	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress"
+	wme_noroot wp theme  install ${WPCLI_THEMES[@]}  --path="${SITE_DIR}/wordpress"
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
@@ -60,33 +60,33 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" "${WPCLI_THEMES[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_gitignore "${SITE_DIR}"
 
 else
-	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
+	printf "\n#\n# Updating ${SITE_DOMAIN}\n#\n"
 
-	git -C $SITE_DIR pull origin master
+	git -C "${SITE_DIR}" pull origin master
 
-	wme_noroot wp core   update                     --path=$SITE_DIR/wordpress
-	wme_noroot wp plugin update ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress
-	wme_noroot wp theme  update ${WPCLI_THEMES[@]}  --path=$SITE_DIR/wordpress
+	wme_noroot wp core   update                     --path="${SITE_DIR}/wordpress"
+	wme_noroot wp plugin update ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress"
+	wme_noroot wp theme  update ${WPCLI_THEMES[@]}  --path="${SITE_DIR}/wordpress"
 fi
 
 
 for i in "${SVN_PLUGINS[@]}"; do
-	if [ ! -d "$SITE_DIR/wp-content/plugins/$i" ]; then
-		svn co https://plugins.svn.wordpress.org/$i/trunk "$SITE_DIR/wp-content/plugins/$i"
+	if [ ! -d "${SITE_DIR}/wp-content/plugins/${i}" ]; then
+		svn co "https://plugins.svn.wordpress.org/${i}/trunk" "${SITE_DIR}/wp-content/plugins/${i}"
 	else
 		(
-			cd "${SITE_DIR}/wp-content/plugins/$i" &&
+			cd "${SITE_DIR}/wp-content/plugins/${i}" &&
 			svn cleanup &&
 			svn up
 		)
 	fi
 done
 
-if [ ! -d "$SITE_DIR/wp-content/plugins/camptix" ]; then
-	git clone https://github.com/Automattic/camptix.git $SITE_DIR/wp-content/plugins/camptix
+if [ ! -d "${SITE_DIR}/wp-content/plugins/camptix" ]; then
+	git clone https://github.com/Automattic/camptix.git "${SITE_DIR}/wp-content/plugins/camptix"
 else
-	git -C $SITE_DIR/wp-content/plugins/camptix pull origin master
+	git -C "${SITE_DIR}/wp-content/plugins/camptix" pull origin master
 fi

--- a/wordpressorg.test/provision/vvv-init.sh
+++ b/wordpressorg.test/provision/vvv-init.sh
@@ -2,90 +2,90 @@
 SITE_DOMAIN="wordpressorg.test"
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-source $BASE_DIR/helper-functions.sh
+source "${BASE_DIR}/helper-functions.sh"
 
-wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
+wme_create_logs "${BASE_DIR}/$SITE_DOMAIN/logs"
 
 if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 	echo "Provisioning of ${SITE_DOMAIN} skipped"
 	return
 fi
 
-PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
-SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
+PROVISION_DIR="${BASE_DIR}/${SITE_DOMAIN}/provision"
+SITE_DIR="${BASE_DIR}/${SITE_DOMAIN}/public_html"
 SVN_PLUGINS=( akismet bbpress debug-bar debug-bar-cron email-post-changes speakerdeck-embed supportflow syntaxhighlighter two-factor wordpress-importer )
 WPCLI_PLUGINS=( jetpack tinymce-code-element wp-multibyte-patch )
 WP_LOCALES=( ja es_ES )
 
-wme_svn_git_migration $SITE_DIR
+wme_svn_git_migration "${SITE_DIR}"
 
-if [ ! -L $SITE_DIR ]; then
-	printf "\n#\n# Provisioning $SITE_DOMAIN\n#\n"
+if [ ! -L "${SITE_DIR}" ]; then
+	printf "\n#\n# Provisioning ${SITE_DOMAIN}\n#\n"
 
-	if [[ ! $MIGRATED_TO_GIT ]]; then
-		wme_import_database "wordpressorg_dev" $PROVISION_DIR
+	if [[ ! "${MIGRATED_TO_GIT}" ]]; then
+		wme_import_database "wordpressorg_dev" "${PROVISION_DIR}"
 	fi
 
-	wme_clone_meta_repository $BASE_DIR
-	wme_symlink_public_dir $BASE_DIR $SITE_DOMAIN "wordpress.org"
-	wme_symlink_logs_dir $BASE_DIR $SITE_DOMAIN "wordpress.org"
+	wme_clone_meta_repository "${BASE_DIR}"
+	wme_symlink_public_dir "${BASE_DIR}" "${SITE_DOMAIN}" "wordpress.org"
+	wme_symlink_logs_dir "${BASE_DIR}" "${SITE_DOMAIN}" "wordpress.org"
 
 	# Setup WordPress, themes, and plugins
-	wme_noroot wp core download --version=nightly --path=$SITE_DIR/wordpress
-	mkdir -p $SITE_DIR/wp-content/mu-plugins
-	cp -f $PROVISION_DIR/wp-config.php             $SITE_DIR
-	cp -f $PROVISION_DIR/wp-cli.yml                $SITE_DIR
-	cp -f $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
-	cp -f $PROVISION_DIR/sunrise.php               $SITE_DIR/wp-content
+	wme_noroot wp core download --version=nightly --path="${SITE_DIR}/wordpress"
+	mkdir -p "${SITE_DIR}/wp-content/mu-plugins"
+	cp -f "${PROVISION_DIR}/wp-config.php"             "${SITE_DIR}"
+	cp -f "${PROVISION_DIR}/wp-cli.yml"                "${SITE_DIR}"
+	cp -f "${PROVISION_DIR}/sandbox-functionality.php" "${SITE_DIR}/wp-content/mu-plugins/"
+	cp -f "${PROVISION_DIR}/sunrise.php"               "${SITE_DIR}/wp-content"
 
-	svn co https://wpcom-themes.svn.automattic.com/p2 $SITE_DIR/wp-content/themes/p2
+	svn co https://wpcom-themes.svn.automattic.com/p2 "${SITE_DIR}/wp-content/themes/p2"
 
 	for i in "${SVN_PLUGINS[@]}"
 	do :
-		svn co https://plugins.svn.wordpress.org/$i/trunk $SITE_DIR/wp-content/plugins/$i
+		svn co "https://plugins.svn.wordpress.org/$i/trunk" "${SITE_DIR}/wp-content/plugins/$i"
 	done
 
-	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress
+	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress"
 
 	# developer.wordpressorg.test
-	cd $SITE_DIR/wp-content/plugins
+	cd "${SITE_DIR}/wp-content/plugins"
 	git clone https://github.com/WordPress/phpdoc-parser.git
 	cd phpdoc-parser
 	wme_noroot composer install
 
 	# translate.wordpressorg.test
-	git clone https://github.com/GlotPress/GlotPress-WP.git $SITE_DIR/wp-content/plugins/glotpress
+	git clone https://github.com/GlotPress/GlotPress-WP.git "${SITE_DIR}/wp-content/plugins/glotpress"
 
 	# global.wordpressorg.test
-	cd $SITE_DIR/wp-content/themes
-	ln -sr $BASE_DIR/meta-repository/global.wordpress.org/public_html/wp-content/themes/rosetta rosetta
-	cd $SITE_DIR/wp-content/mu-plugins
-	ln -sr $BASE_DIR/meta-repository/global.wordpress.org/public_html/wp-content/mu-plugins global_wordpressorg_dev
+	cd "${SITE_DIR}/wp-content/themes"
+	ln -sr "${BASE_DIR}/meta-repository/global.wordpress.org/public_html/wp-content/themes/rosetta" rosetta
+	cd "${SITE_DIR}/wp-content/mu-plugins"
+	ln -sr "${BASE_DIR}/meta-repository/global.wordpress.org/public_html/wp-content/mu-plugins" global_wordpressorg_dev
 
-	mkdir $SITE_DIR/wp-content/languages
-	mkdir $SITE_DIR/wp-content/languages/themes
-	mkdir $SITE_DIR/wp-content/languages/plugins
+	mkdir "${SITE_DIR}/wp-content/languages"
+	mkdir "${SITE_DIR}/wp-content/languages/themes"
+	mkdir "${SITE_DIR}/wp-content/languages/plugins"
 
-	wme_noroot wp language core install ${WP_LOCALES[@]} --path=$SITE_DIR/wordpress
-	wme_noroot wp language core update --path=$SITE_DIR/wordpress # Get plugin/theme translations
+	wme_noroot wp language core install ${WP_LOCALES[@]} --path="${SITE_DIR}/wordpress"
+	wme_noroot wp language core update --path="${SITE_DIR}/wordpress" # Get plugin/theme translations
 
 	printf "Installing translations from translate.wordpress.org..."
 	for locale in "${WP_LOCALES[@]}"
 	do :
 		gplocale=${locale%_*}
 
-		wme_download_pomo "${gplocale}" "meta/rosetta" "$SITE_DIR/wp-content/languages/plugins/rosetta-${locale}"
-		wme_download_pomo "${gplocale}" "meta/themes" "$SITE_DIR/wp-content/languages/plugins/wporg-themes-${locale}"
-		wme_download_pomo "${gplocale}" "meta/plugins-v3" "$SITE_DIR/wp-content/languages/plugins/wporg-plugins-${locale}"
-		wme_download_pomo "${gplocale}" "meta/forums" "$SITE_DIR/wp-content/languages/themes/wporg-forums-${locale}"
-		wme_download_pomo "${gplocale}" "meta/p2-breathe" "$SITE_DIR/wp-content/languages/themes/p2-breathe-${locale}"
-		wme_download_pomo "${gplocale}" "meta/o2" "$SITE_DIR/wp-content/languages/themes/o2-${locale}"
+		wme_download_pomo "${gplocale}" "meta/rosetta" "${SITE_DIR}/wp-content/languages/plugins/rosetta-${locale}"
+		wme_download_pomo "${gplocale}" "meta/themes" "${SITE_DIR}/wp-content/languages/plugins/wporg-themes-${locale}"
+		wme_download_pomo "${gplocale}" "meta/plugins-v3" "${SITE_DIR}/wp-content/languages/plugins/wporg-plugins-${locale}"
+		wme_download_pomo "${gplocale}" "meta/forums" "${SITE_DIR}/wp-content/languages/themes/wporg-forums-${locale}"
+		wme_download_pomo "${gplocale}" "meta/p2-breathe" "${SITE_DIR}/wp-content/languages/themes/p2-breathe-${locale}"
+		wme_download_pomo "${gplocale}" "meta/o2" "${SITE_DIR}/wp-content/languages/themes/o2-${locale}"
 	done
 
 	# Cavalcade
 	printf "Installing Cavalcade..."
-	git clone https://github.com/humanmade/Cavalcade.git $SITE_DIR/wp-content/mu-plugins/cavalcade
-	cp -f $PROVISION_DIR/cavalcade.php $SITE_DIR/wp-content/mu-plugins/
+	git clone https://github.com/humanmade/Cavalcade.git "${SITE_DIR}/wp-content/mu-plugins/cavalcade"
+	cp -f "${PROVISION_DIR}/cavalcade.php" "${SITE_DIR}/wp-content/mu-plugins/"
 
 	if [[ ! -d "/etc/cavalcade" ]]; then
 		git clone https://github.com/humanmade/Cavalcade-Runner.git /etc/cavalcade
@@ -94,7 +94,7 @@ if [ ! -L $SITE_DIR ]; then
 	fi
 
 	mkdir -p "/etc/init/"
-	cp -f "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
+	cp -f "${PROVISION_DIR}/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
 	service cavalcade-wordpressorg restart
 
 	# Ignore external dependencies and Meta Environment tweaks
@@ -116,50 +116,50 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-cli.yml
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${SVN_PLUGINS[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_gitignore "${SITE_DIR}"
 
 else
-	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
+	printf "\n#\n# Updating ${SITE_DOMAIN}\n#\n"
 
-	git -C $SITE_DIR pull origin master
-	wme_noroot wp core   update --version=nightly   --path=$SITE_DIR/wordpress
-	wme_noroot wp plugin update ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress
-	wme_noroot wp language core update              --path=$SITE_DIR/wordpress
-	svn up $SITE_DIR/wp-content/themes/p2
+	git -C "${SITE_DIR}" pull origin master
+	wme_noroot wp core   update --version=nightly   --path="${SITE_DIR}/wordpress"
+	wme_noroot wp plugin update ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress"
+	wme_noroot wp language core update              --path="${SITE_DIR}/wordpress"
+	svn up "${SITE_DIR}/wp-content/themes/p2"
 
 	printf "Updating translations from translate.wordpress.org..."
 	for locale in "${WP_LOCALES[@]}"
 	do :
 		gplocale=${locale%_*}
 
-		wme_download_pomo "${gplocale}" "meta/rosetta" "$SITE_DIR/wp-content/languages/plugins/rosetta-${locale}"
-		wme_download_pomo "${gplocale}" "meta/themes" "$SITE_DIR/wp-content/languages/plugins/wporg-themes-${locale}"
-		wme_download_pomo "${gplocale}" "meta/plugins-v3" "$SITE_DIR/wp-content/languages/plugins/wporg-plugins-${locale}"
-		wme_download_pomo "${gplocale}" "meta/forums" "$SITE_DIR/wp-content/languages/themes/wporg-forums-${locale}"
-		wme_download_pomo "${gplocale}" "meta/p2-breathe" "$SITE_DIR/wp-content/languages/themes/p2-breathe-${locale}"
-		wme_download_pomo "${gplocale}" "meta/o2" "$SITE_DIR/wp-content/languages/themes/o2-${locale}"
+		wme_download_pomo "${gplocale}" "meta/rosetta" "${SITE_DIR}/wp-content/languages/plugins/rosetta-${locale}"
+		wme_download_pomo "${gplocale}" "meta/themes" "${SITE_DIR}/wp-content/languages/plugins/wporg-themes-${locale}"
+		wme_download_pomo "${gplocale}" "meta/plugins-v3" "${SITE_DIR}/wp-content/languages/plugins/wporg-plugins-${locale}"
+		wme_download_pomo "${gplocale}" "meta/forums" "${SITE_DIR}/wp-content/languages/themes/wporg-forums-${locale}"
+		wme_download_pomo "${gplocale}" "meta/p2-breathe" "${SITE_DIR}/wp-content/languages/themes/p2-breathe-${locale}"
+		wme_download_pomo "${gplocale}" "meta/o2" "${SITE_DIR}/wp-content/languages/themes/o2-${locale}"
 	done
 
 	for i in "${SVN_PLUGINS[@]}"
 	do :
-		svn up $SITE_DIR/wp-content/plugins/$i
+		svn up "${SITE_DIR}/wp-content/plugins/${i}"
 	done
 
 	# developer.wordpressorg.test
-	git -C $SITE_DIR/wp-content/plugins/phpdoc-parser pull
+	git -C "${SITE_DIR}/wp-content/plugins/phpdoc-parser" pull
 
 	# translate.wordpressorg.test
-	git -C $SITE_DIR/wp-content/plugins/glotpress pull
+	git -C "${SITE_DIR}/wp-content/plugins/glotpress" pull
 
 	# Cavalcade
-	git -C $SITE_DIR/wp-content/mu-plugins/cavalcade pull
+	git -C "${SITE_DIR}/wp-content/mu-plugins/cavalcade" pull
 	git -C /etc/cavalcade pull
-	cp -f "$PROVISION_DIR/cavalcade.php" "$SITE_DIR/wp-content/mu-plugins/"
+	cp -f "${PROVISION_DIR}/cavalcade.php" "${SITE_DIR}/wp-content/mu-plugins/"
 	mkdir -p "/etc/init"
-	cp -f "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
+	cp -f "${PROVISION_DIR}/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
 	service cavalcade-wordpressorg restart
 fi
 
 # Pull global header/footer
-wme_pull_wporg_global_header $SITE_DIR
-wme_pull_wporg_global_footer $SITE_DIR
+wme_pull_wporg_global_header "${SITE_DIR}"
+wme_pull_wporg_global_footer "${SITE_DIR}"

--- a/wordpresstv.test/provision/vvv-init.sh
+++ b/wordpresstv.test/provision/vvv-init.sh
@@ -2,39 +2,39 @@
 SITE_DOMAIN="wordpresstv.test"
 
 BASE_DIR=$( dirname $( dirname $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) ) )
-source $BASE_DIR/helper-functions.sh
+source "${BASE_DIR}/helper-functions.sh"
 
-wme_create_logs "$BASE_DIR/$SITE_DOMAIN/logs"
+wme_create_logs "${BASE_DIR}/${SITE_DOMAIN}/logs"
 
 if [[ `wme_provision_site "${SITE_DOMAIN}"` == 'false' ]]; then
 	echo "Provisioning of ${SITE_DOMAIN} skipped"
 	return
 fi
 
-PROVISION_DIR="$BASE_DIR/$SITE_DOMAIN/provision"
-SITE_DIR="$BASE_DIR/$SITE_DOMAIN/public_html"
+PROVISION_DIR="${BASE_DIR}/${SITE_DOMAIN}/provision"
+SITE_DIR="${BASE_DIR}/${SITE_DOMAIN}/public_html"
 WPCLI_PLUGINS=( jetpack )
 
-wme_svn_git_migration $SITE_DIR
+wme_svn_git_migration "${SITE_DIR}"
 
-if [ ! -L $SITE_DIR ]; then
-	printf "\n#\n# Provisioning $SITE_DOMAIN\n#\n"
+if [ ! -L "${SITE_DIR}" ]; then
+	printf "\n#\n# Provisioning ${SITE_DOMAIN}\n#\n"
 
-	if [[ ! $MIGRATED_TO_GIT ]]; then
-		wme_import_database "wordpresstv_dev" $PROVISION_DIR
+	if [[ ! "${MIGRATED_TO_GIT}" ]]; then
+		wme_import_database "wordpresstv_dev" "${PROVISION_DIR}"
 	fi
 
-	wme_clone_meta_repository $BASE_DIR
-	wme_symlink_public_dir $BASE_DIR $SITE_DOMAIN "wordpress.tv"
-	wme_symlink_logs_dir $BASE_DIR $SITE_DOMAIN "wordpress.tv"
+	wme_clone_meta_repository "${BASE_DIR}"
+	wme_symlink_public_dir "${BASE_DIR}" "$SITE_DOMAIN" "wordpress.tv"
+	wme_symlink_logs_dir "${BASE_DIR}" "$SITE_DOMAIN" "wordpress.tv"
 
 	# Setup WordPress and plugins
-	wme_noroot wp core download --version=nightly --path=$SITE_DIR/wordpress
-	mkdir -p $SITE_DIR/wp-content/mu-plugins
-	mkdir -p $SITE_DIR/wp-content/plugins
-	cp $PROVISION_DIR/wp-config.php             $SITE_DIR
-	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
-	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path=$SITE_DIR/wordpress
+	wme_noroot wp core download --version=nightly --path="${SITE_DIR}/wordpress"
+	mkdir -p "${SITE_DIR}/wp-content/mu-plugins"
+	mkdir -p "${SITE_DIR}/wp-content/plugins"
+	cp "$PROVISION_DIR/wp-config.php"             "${SITE_DIR}"
+	cp "$PROVISION_DIR/sandbox-functionality.php" "${SITE_DIR}/wp-content/mu-plugins/"
+	wme_noroot wp plugin install ${WPCLI_PLUGINS[@]} --path="${SITE_DIR}/wordpress"
 
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
@@ -43,13 +43,13 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-config.php
 	)
 	IGNORED_FILES=( "${IGNORED_FILES[@]}" "${WPCLI_PLUGINS[@]}" )
-	wme_create_gitignore $SITE_DIR
+	wme_create_gitignore "${SITE_DIR}"
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
 
-	git -C $SITE_DIR pull origin master
-	wme_noroot wp core   update --version=nightly --path=$SITE_DIR/wordpress
-	wme_noroot wp plugin update --all             --path=$SITE_DIR/wordpress
+	git -C "${SITE_DIR}" pull origin master
+	wme_noroot wp core   update --version=nightly --path="${SITE_DIR}/wordpress"
+	wme_noroot wp plugin update --all             --path="${SITE_DIR}/wordpress"
 
 fi


### PR DESCRIPTION
This fixes a security/maintenance issue. The easiest way to trigger this is to put a space in the site name e.g. `"wp meta":` instead of `wp-meta:`.

This needs some testing, which is still on my todo list

Closes #151 